### PR TITLE
[PRO-2994] - Adding support for revocation failures

### DIFF
--- a/src/ui/agents/KivaAgent.ts
+++ b/src/ui/agents/KivaAgent.ts
@@ -40,7 +40,14 @@ export default class KivaAgent extends BaseAgent implements IAgent {
     }
 
     isVerified(response: any): boolean {
-        if (response.state === "verified") {
+        if (response.state === "verified" && response.verified === true) {
+            return true;
+        }
+        return false;
+    }
+
+    isRejected(response: any): boolean {
+        if (response.state === "verified" && response.verified === false) {
             return true;
         }
         return false;

--- a/src/ui/interfaces/AgentInterfaces.ts
+++ b/src/ui/interfaces/AgentInterfaces.ts
@@ -15,5 +15,6 @@ export interface IAgent {
     isConnected(response: any): boolean,
     isVerified(response: any): boolean,
     getProof(response: any): any,
-    formatProof(response: any): any
+    formatProof(response: any): any,
+    isRejected?: (response: any) => boolean
 }

--- a/src/ui/screens/AgencyQR.tsx
+++ b/src/ui/screens/AgencyQR.tsx
@@ -113,6 +113,8 @@ export default class AgencyQR extends React.Component<QRProps, QRState> {
             let verificationStatus: any = await this.agent.checkVerification(verificationId);
             if (this.agent.isVerified(verificationStatus)) {
                 this.acceptProof(this.agent.getProof(verificationStatus));
+            } else if (!!this.agent.isRejected && this.agent.isRejected(verificationStatus)) {
+                throw I18n.getKey('REJECTED_PROOF');
             } else if (!cancel) {
                 setTimeout(() => {
                     this.pollVerification(verificationId);

--- a/test/fixtures/kiva_agent.json
+++ b/test/fixtures/kiva_agent.json
@@ -42,8 +42,13 @@
         "unverified": {
             "state": "jinkies"
         },
+        "rejected": {
+            "state": "verified",
+            "verified": false
+        },
         "verified": {
             "state": "verified",
+            "verified": true,
             "presentation": {
                 "requested_proof": {
                     "revealed_attrs": {

--- a/test/functional/qr_scan_spec.js
+++ b/test/functional/qr_scan_spec.js
@@ -140,10 +140,54 @@ describe('QR Code Scan screen should...', function() {
         cy.get('.dialog-icon.error').should('be.visible');
     });
 
-    it('should render user details if the proof is sucessful', function() {
-        let verifyConf = conf.sendVerification,
+    it('should show an error if the proof request is rejected', function() {
+        let establishConf = conf.establishConnection,
+            getConf = conf.getConnection,
+            establishResponseBody = establishConf.success,
+            connectResponseBody = getConf.active,
+            verifyConf = conf.sendVerification,
             checkConf = conf.checkVerification;
 
+        cy.intercept(establishConf.method, establishConf.endpoint, {
+            ...common,
+            body: establishResponseBody
+        });
+        cy.intercept(getConf.method, getConf.endpoint, {
+            ...common,
+            body: connectResponseBody
+        });
+        cy.intercept(verifyConf.method, verifyConf.endpoint, {
+            ...common,
+            body: verifyConf.success
+        });
+        cy.intercept(checkConf.method, checkConf.endpoint, {
+            ...common,
+            body: checkConf.rejected
+        });
+
+        cy.get('[data-cy="reset-flow"]').click();
+        cy.wait(300);
+        cy.get('[data-cy="qr-scan-next"]').click();
+        cy.get('.dialog-icon.error').should('be.visible');
+        cy.get('#instructions').should('contain', 'Verification Failed: This credential may have been revoked.');
+    });
+
+    it('should render user details if the proof is sucessful', function() {
+        let establishConf = conf.establishConnection,
+            getConf = conf.getConnection,
+            establishResponseBody = establishConf.success,
+            connectResponseBody = getConf.active,
+            verifyConf = conf.sendVerification,
+            checkConf = conf.checkVerification;
+
+        cy.intercept(establishConf.method, establishConf.endpoint, {
+            ...common,
+            body: establishResponseBody
+        });
+        cy.intercept(getConf.method, getConf.endpoint, {
+            ...common,
+            body: connectResponseBody
+        });
         cy.intercept(verifyConf.method, verifyConf.endpoint, {
             ...common,
             body: verifyConf.success
@@ -152,6 +196,9 @@ describe('QR Code Scan screen should...', function() {
             ...common,
             body: checkConf.verified
         });
+
+        cy.get('[data-cy="reset-flow"]').click();
+        cy.wait(300);
         cy.get('[data-cy="qr-scan-next"]').click();
         cy.get('.ProfileCard').should('be.visible');
     });

--- a/tools/bundle/MessageBuilder.js
+++ b/tools/bundle/MessageBuilder.js
@@ -26,6 +26,7 @@ const messageMap = {
     NO_EMAIL: "Errors.email.noInput",
     INVALID_PHONE_NUMBER_INPUT: "Errors.input.missingPhoneNumber",
     INVALID_OTP_ENTRY: "Errors.input.invalidOTP",
+    REJECTED_PROOF: "Errors.qr.rejectedProof",
     // QR Code
     CLICK_VERIFY: "QR.text.clickVerify",
     RETRIEVING_QR: "QR.text.retrieving",

--- a/tools/language/en/default.json
+++ b/tools/language/en/default.json
@@ -18,7 +18,8 @@
             "noInviteUrl": "There was an error creating the QR code. Please try again and contact your IT department if the error persists.",
             "connectionError": "There was an error establishing a connection. Please try again and contact your IT department if the error persists.",
             "notConnected": "Please scan the QR code and establish a connection before you verify",
-            "noConnectionFound": "Could not find a record of connection [ {{connectionId}} ]"
+            "noConnectionFound": "Could not find a record of connection [ {{connectionId}} ]",
+            "rejectedProof": "Verification Failed: This credential may have been revoked."
         },
         "email": {
             "noInput": "Please enter your email in the field below"


### PR DESCRIPTION
* Add translation string for rejected proofs
* Add an optional `isRejected` method to the `IBaseAgent` definition
* Implement `isRejected` for `KivaAgent`
* Add handling for rejections in `AgencyQR`
* Add test for rejections
* Fix tests that seemed to be failing otherwise